### PR TITLE
taiga #115 exchange dashboard

### DIFF
--- a/exchange/src/App.tsx
+++ b/exchange/src/App.tsx
@@ -70,12 +70,12 @@ function App() {
             lg: '32px',
             xl: '40px',
           },
-          padding: {
-            xs: '24px 16px',
-            md: '42px 54px',
-            lg: '56px 72px',
-            xl: '70px 90px',
-          },
+          // padding: {
+          //   xs: '24px 16px',
+          //   md: '42px 54px',
+          //   lg: '56px 72px',
+          //   xl: '70px 90px',
+          // },
         }}
       >
         <Grid container spacing={4}>
@@ -125,7 +125,7 @@ function App() {
       </Box>
 
       {isConnected && (
-        <div className="fixed  z-[100] top-[2%] right-[2%] p-[0.5rem] gap-[2%] rounded-[100px] w-[300px] flex justify-end">
+        <div className="fixed  z-[100] top-[2%] right-[2%] p-[0.5rem] gap-[2%] rounded-[100px] w-[100px] flex justify-end">
           <div className="fixed left-4 top-[1%] p-[0.5rem] w-[250px]  rounded-[100px] text-center">
             {/* <div>Connected to </div> */}
           </div>

--- a/exchange/src/App.tsx
+++ b/exchange/src/App.tsx
@@ -59,7 +59,7 @@ function App() {
   }, [isDisconnected]);
 
   return (
-    <Box sx={{ px: { xs: 1, sm: 2, md: 3, lg: 4, xl: 5 }, pt: 10 }}>
+    <Box sx={{ px: { xs: 1, sm: 2, md: 3, lg: 4, xl: 5 }, pt: 10, mt:5 }}>
       <Box
         sx={{
           background: '#f6f7fe',
@@ -70,12 +70,13 @@ function App() {
             lg: '32px',
             xl: '40px',
           },
-          // padding: {
-          //   xs: '24px 16px',
-          //   md: '42px 54px',
-          //   lg: '56px 72px',
-          //   xl: '70px 90px',
-          // },
+          padding: {
+            xs: '24px 16px',
+            md: '42px 54px',
+            lg: '56px 72px',
+            xl: '70px 90px',
+          },
+          
         }}
       >
         <Grid container spacing={4}>
@@ -101,7 +102,7 @@ function App() {
               ></Link>
             </Grid>
           )}
-          <Grid item xs={12} sm={12} md={id ? 12 : 7} lg={id ? 12 : 7}>
+          <Grid item xs={12} sm={12} md={id ? 12 : 7} lg={id ? 12 : 7} >
             <Box mt={3}>
               {!isConnected && (
                 <>

--- a/exchange/src/components/Dashboard.tsx
+++ b/exchange/src/components/Dashboard.tsx
@@ -62,7 +62,7 @@ export const Dashboard = ({}) => {
             borderBottom: 1,
             borderColor: 'divider',
             position: 'fixed',
-            // left: '20%',
+            left: '0%',
             top: 0,
             padding: '1rem',
             background: 'white',
@@ -87,7 +87,7 @@ export const Dashboard = ({}) => {
         </Box>
         <Box display="flex" justifyContent="center">
           <TabPanel value={value} index={0}>
-            <section className="flex items-center justify-center absolute top-0 left-0   w-full ">
+            <section className="flex items-center justify-center absolute top-10 left-0   w-full ">
               <div className=" bg-[#f6f7fe] mx-[2rem] rounded-[20px] w-full mt-[80px] p-[4rem]">
                 <JobDashboard />
               </div>

--- a/exchange/src/components/Dashboard.tsx
+++ b/exchange/src/components/Dashboard.tsx
@@ -62,11 +62,11 @@ export const Dashboard = ({}) => {
             borderBottom: 1,
             borderColor: 'divider',
             position: 'fixed',
-            left: '20%',
+            // left: '20%',
             top: 0,
             padding: '1rem',
             background: 'white',
-            width: '50%',
+            width: '100%',
             display: 'flex',
             justifyContent: 'center',
             zIndex: 20,
@@ -88,7 +88,7 @@ export const Dashboard = ({}) => {
         <Box display="flex" justifyContent="center">
           <TabPanel value={value} index={0}>
             <section className="flex items-center justify-center absolute top-0 left-0   w-full ">
-              <div className=" bg-[#f6f7fe] mx-[2rem] rounded-[20px] w-full min-h-[100vh] mt-[80px] p-[4rem]">
+              <div className=" bg-[#f6f7fe] mx-[2rem] rounded-[20px] w-full mt-[80px] p-[4rem]">
                 <JobDashboard />
               </div>
             </section>


### PR DESCRIPTION
full width and changed view height.

web3 button overlaps with the other components on smaller devices, couldn't click on smaller devices. changed the width of the underlying box so it will just be cosmetic for now, so you can still click on escrow on smaller devices. 
<img width="498" alt="Screenshot 2023-05-03 at 13 49 05" src="https://user-images.githubusercontent.com/94614129/235859768-438ff83e-fa61-4306-bbf0-c12191667f9a.png">
